### PR TITLE
Change PORT to WEB_PORT env var

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,6 +1,6 @@
 
 var config = {
-  defaultPort: process.env.PORT || 3000,
+  defaultPort: process.env.WEB_PORT || 3000,
   defaultLogLength: process.env.LOGLENGTH || 64,
   defaultLogLines: process.env.LOGLINES || 10,
   defaultSpacer: process.env.SPACER || ' | ',


### PR DESCRIPTION
conflicts with `PORT` variable injected by Marathon making it unusable in bridge mode.